### PR TITLE
Bugfix for duplicate filenames

### DIFF
--- a/svn-vimdifftab.py
+++ b/svn-vimdifftab.py
@@ -52,6 +52,14 @@ def copy_if_tmp(file_dir, file_name, file_description):
     elif not os.path.isabs(file_name): return file_name
 
     file_name_out = os.path.join(file_dir, file_name_base)
+    if os.path.exists(file_name_out):
+        suffix = 0
+        while True:
+            suffix += 1
+            base, ext = os.path.splitext(file_name_out)
+            file_name_out = base + '.' + str(suffix) + ext
+            if not os.path.exists(file_name_out):
+                break
     shutil.copy(file_name, file_name_out)
     return file_name_out
 

--- a/svn-vimdifftab.py
+++ b/svn-vimdifftab.py
@@ -32,7 +32,7 @@
 # policies, either expressed or implied, of Chris Pick.
 
 
-import sys, re, subprocess, os, os.path, tempfile, shutil
+import sys, re, subprocess, os, os.path, tempfile, time, shutil
 
 def sanitize(file_description):
     file_description = re.sub(r'\s+', r'\ ', file_description)
@@ -59,6 +59,9 @@ def copy_if_tmp(file_dir, file_name, file_description):
 manifest_file_name = os.getenv('SVN_VIMDIFFTAB')
 if manifest_file_name != None:
     # TODO use lockfile
+    while os.path.exists(manifest_file_name + '.lock'):
+        time.sleep(0.01)
+    os.mknod(manifest_file_name + '.lock')
 
     file_dir = os.path.dirname(manifest_file_name)
 
@@ -73,6 +76,10 @@ if manifest_file_name != None:
     manifest_file.write(file_description1 + '\n' + file_description2 + '\n'
             + file_name1 + '\n' + file_name2 + '\n');
 
+    manifest_file.flush()
+    os.fsync(manifest_file.fileno())
+    manifest_file.close()
+    os.remove(manifest_file_name + '.lock')
     sys.exit(0)
 
 # create the dir and pass it to the children


### PR DESCRIPTION
When using this script to show svn diffs in vim, if multiple files with the same name have been changed, some of them will be overwritten by each other during the copy action to /tmp that this script performs. This PR ensures names are unique before copying. I also implemented a locking mechanism for the manifest file whilst I was debugging the bug, since there was a TODO for that anyway.